### PR TITLE
Correct implementation of setters/getters or input/output derivatives 

### DIFF
--- a/src/FMI2.jl
+++ b/src/FMI2.jl
@@ -1052,8 +1052,8 @@ the array order specifies the corresponding order of derivation of the variables
 
 For more information call ?fmi2SetRealInputDerivatives
 """
-function fmi2SetRealInputDerivatives(fmu::FMU2, vr::fmi2ValueReference, nvr::Cint, order::Integer, value::Real)
-    fmi2SetRealInputDerivatives(fmu.components[end], vr, nvr, fmi2Integer(order), fmi2Real(value))
+function fmi2SetRealInputDerivatives(fmu::FMU2, vr::fmi2ValueReferenceFormat, order::Union{Array{<:Integer}, <:Integer}, value::Union{Array{<:Real}, <:Real})
+    fmi2SetRealInputDerivatives(fmu.components[end], vr, order, value)
 end
 
 """
@@ -1066,8 +1066,8 @@ the array order specifies the corresponding order of derivation of the variables
 
 For more information call ?fmi2GetRealOutputDerivatives
 """
-function fmi2GetRealOutputDerivatives(fmu::FMU2, vr::fmi2ValueReference, nvr::Cint, order::Integer, value::Real)
-    fmi2GetRealOutputDerivatives(fmu.components[end], vr, nvr, fmi2Integer(order), fmi2Real(value))
+function fmi2GetRealOutputDerivatives(fmu::FMU2, vr::fmi2ValueReferenceFormat, order::Union{Array{<:Integer}, <:Integer})
+    fmi2GetRealOutputDerivatives(fmu.components[end], vr, order)
 end
 
 """

--- a/src/FMI2_c.jl
+++ b/src/FMI2_c.jl
@@ -797,7 +797,7 @@ Sets the n-th time derivative of real input variables.
 vr defines the value references of the variables
 the array order specifies the corresponding order of derivation of the variables
 """
-function fmi2SetRealInputDerivatives(c::fmi2Component, vr::fmi2ValueReference, nvr::Unsigned, order::fmi2Integer, value::fmi2Real)
+function fmi2SetRealInputDerivatives(c::fmi2Component, vr::Array{fmi2ValueReference}, nvr::Csize_t, order::Array{fmi2Integer}, value::Array{fmi2Real})
     status = ccall(c.fmu.cSetRealInputDerivatives,
                 Cuint,
                 (Ptr{Nothing}, Ptr{Cint}, Csize_t, Ptr{Cint}, Ptr{Cdouble}),
@@ -811,11 +811,12 @@ Retrieves the n-th derivative of output values.
 vr defines the value references of the variables
 the array order specifies the corresponding order of derivation of the variables
 """
-function fmi2GetRealOutputDerivatives(c::fmi2Component,  vr::fmi2ValueReference, nvr::Unsigned, order::fmi2Integer, value::fmi2Real)
-    status = ccall(c.fmu.cGetRealOutputDerivatives,
+function fmi2GetRealOutputDerivatives(c::fmi2Component,  vr::Array{fmi2ValueReference}, nvr::Csize_t, order::Array{fmi2Integer}, value::Array{fmi2Real})
+    c.fmu.cGetRealOutputDerivatives     = dlsym(c.fmu.libHandle, :fmi2GetRealOutputDerivatives)
+    ccall(c.fmu.cGetRealOutputDerivatives,
                 Cuint,
                 (Ptr{Nothing}, Ptr{Cint}, Csize_t, Ptr{Cint}, Ptr{Cdouble}),
-                c.compAddr, Ref(vr), nvr, Ref(order), Ref(value))
+                c.compAddr, vr, nvr, order, value)
 end
 
 """

--- a/src/FMI2_c.jl
+++ b/src/FMI2_c.jl
@@ -812,7 +812,6 @@ vr defines the value references of the variables
 the array order specifies the corresponding order of derivation of the variables
 """
 function fmi2GetRealOutputDerivatives(c::fmi2Component,  vr::Array{fmi2ValueReference}, nvr::Csize_t, order::Array{fmi2Integer}, value::Array{fmi2Real})
-    c.fmu.cGetRealOutputDerivatives     = dlsym(c.fmu.libHandle, :fmi2GetRealOutputDerivatives)
     ccall(c.fmu.cGetRealOutputDerivatives,
                 Cuint,
                 (Ptr{Nothing}, Ptr{Cint}, Csize_t, Ptr{Cint}, Ptr{Cdouble}),

--- a/src/FMI2_c.jl
+++ b/src/FMI2_c.jl
@@ -801,7 +801,7 @@ function fmi2SetRealInputDerivatives(c::fmi2Component, vr::Array{fmi2ValueRefere
     status = ccall(c.fmu.cSetRealInputDerivatives,
                 Cuint,
                 (Ptr{Nothing}, Ptr{Cint}, Csize_t, Ptr{Cint}, Ptr{Cdouble}),
-                c.compAddr, Ref(vr), nvr, Ref(order), Ref(value))
+                c.compAddr, vr, nvr, order, value)
 end
 
 """

--- a/src/FMI2_comp.jl
+++ b/src/FMI2_comp.jl
@@ -468,8 +468,6 @@ function fmi2GetRealOutputDerivatives(c::fmi2Component, vr::fmi2ValueReferenceFo
     order = prepareValue(order)
     nvr = Csize_t(length(vr))
     values = zeros(fmi2Real, nvr)
-    # @assert length(vr) == length(values) "fmi2SetReal(...): `vr` and `values` need to be the same length."
-    
     fmi2GetRealOutputDerivatives(c, vr, nvr, Array{fmi2Integer}(order), values)
     
     if length(values) == 1

--- a/src/FMI2_comp.jl
+++ b/src/FMI2_comp.jl
@@ -458,10 +458,28 @@ function fmi2GetDirectionalDerivative(c::fmi2Component,
 end
 
 # CoSimulation specific functions
+"""
+TODO: FMI specification reference.
+
+Sets the n-th time derivative of real input variables.
+vr defines the value references of the variables
+the array order specifies the corresponding order of derivation of the variables
+"""
+function fmi2SetRealInputDerivatives(c::fmi2Component, vr::fmi2ValueReferenceFormat, order, values)
+    vr = prepareValueReference(c, vr)
+    order = prepareValue(order)
+    values = prepareValue(values)
+    nvr = Csize_t(length(vr))
+    fmi2SetRealInputDerivatives(c, vr, nvr, Array{fmi2Integer}(order), Array{fmi2Real}(values))
+end
 
 """
 TODO: FMI specification reference.
 
+vr defines the value references of the variables
+the array order specifies the corresponding order of derivation of the variables
+
+For more information call ?fmi2GetRealOutputDerivatives
 """
 function fmi2GetRealOutputDerivatives(c::fmi2Component, vr::fmi2ValueReferenceFormat, order)
     vr = prepareValueReference(c, vr)

--- a/src/FMI2_comp.jl
+++ b/src/FMI2_comp.jl
@@ -462,6 +462,26 @@ end
 """
 TODO: FMI specification reference.
 
+"""
+function fmi2GetRealOutputDerivatives(c::fmi2Component, vr::fmi2ValueReferenceFormat, order)
+    vr = prepareValueReference(c, vr)
+    order = prepareValue(order)
+    nvr = Csize_t(length(vr))
+    values = zeros(fmi2Real, nvr)
+    # @assert length(vr) == length(values) "fmi2SetReal(...): `vr` and `values` need to be the same length."
+    
+    fmi2GetRealOutputDerivatives(c, vr, nvr, Array{fmi2Integer}(order), values)
+    
+    if length(values) == 1
+        return values[1]
+    else
+        return values
+    end
+end
+
+"""
+TODO: FMI specification reference.
+
 The computation of a time step is started.
 
 For more information call ?fmi2DoStep

--- a/test/getter_setter.jl
+++ b/test/getter_setter.jl
@@ -119,6 +119,14 @@ fmiGetBoolean!(fmuStruct, booleanValueReferences, cacheBoolean)
 fmiGetString!(fmuStruct, stringValueReferences, cacheString)
 @test cacheString == rndString
 
+if envFMUSTRUCT == "FMUCOMPONENT"
+    dirs = fmi2GetRealOutputDerivatives(fmuStruct, realValueReferences, ones(2))
+    @test dirs isa AbstractArray{<:Real}
+    @test dirs |> length == 2
+
+    st = fmi2SetRealInputDerivatives(fmuStruct, realValueReferences, ones(2), zeros(2))
+    @test_broken st == FMI.fmi2OK
+end
 # this is not suppoerted by OMEdit-FMUs in the repository
 if ENV["EXPORTINGTOOL"] != "OpenModelica/v1.17.0"
     @test fmiGetStartValue(fmuStruct, ["p_enumeration", "p_string", "p_real"]) == ["myEnumeration1", "Hello World!", 0.0]


### PR DESCRIPTION
Tests are missing for these functions. I don't think the current set of test FMUs in `/models` can be used for testing.

TODO:

- [x] Correct the implementation of `fmi2GetRealOutputDerivatives`.
- [x] Correct the implementation of `fmi2SetRealInputDerivatives`.
- [x] Add tests.
- [x] Add docstrings.