### PR TITLE
Allow loaded FMU to support both CS and ME when available

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "FMI"
 uuid = "14a09403-18e3-468f-ad8a-74f8dda2d9ac"
 authors = ["TT <tobias.thummerer@informatik.uni-augsburg.de>", "LM <lars.mikelsons@informatik.uni-augsburg.de>", "JK <josef.kircher@student.uni-augsburg.de>"]
-version = "0.3.2"
+version = "0.3.3"
 
 [deps]
 DiffEqCallbacks = "459566f4-90b8-5000-8ac3-15dfb0a30def"

--- a/src/FMI.jl
+++ b/src/FMI.jl
@@ -194,7 +194,7 @@ end
 Returns the tag 'modelIdentifier' from CS or ME section.
 """
 function fmiGetModelIdentifier(fmu::FMU2)
-    fmi2GetModelIdentifier(fmu)
+    fmi2GetModelIdentifier(fmu.modelDescription; type=fmu.type)
 end
 
 """
@@ -237,8 +237,8 @@ end
 """
 Load FMUs independent of the FMI version, currently supporting version 2.0.X.
 """
-function fmiLoad(pathToFMU::String; unpackPath=nothing)
-    fmi2Load(pathToFMU; unpackPath=unpackPath)
+function fmiLoad(pathToFMU::String; unpackPath=nothing, type=nothing)
+    fmi2Load(pathToFMU; unpackPath=unpackPath, type=type)
 end
 
 """

--- a/src/FMI2.jl
+++ b/src/FMI2.jl
@@ -294,7 +294,7 @@ Returns the instance of the FMU struct.
 
 Via optional argument ```unpackPath```, a path to unpack the FMU can be specified (default: system temporary directory).
 """
-function fmi2Load(pathToFMU::String; unpackPath=nothing)
+function fmi2Load(pathToFMU::String; unpackPath=nothing, type=nothing)
     # Create uninitialized FMU
     fmu = FMU2()
     fmu.components = []
@@ -312,7 +312,16 @@ function fmi2Load(pathToFMU::String; unpackPath=nothing)
     fmu.modelDescription = fmi2ReadModelDescription(pathToModelDescription)
     fmu.modelName = fmu.modelDescription.modelName
     fmu.instanceName = fmu.modelDescription.modelName
-    fmuName = fmi2GetModelIdentifier(fmu.modelDescription) # tmpName[length(tmpName)]
+
+    if (fmi2IsCoSimulation(fmu) && fmi2IsModelExchange(fmu) && (type===nothing || type==:CS)) || fmi2IsCoSimulation(fmu)
+        fmu.type = fmi2CoSimulation::fmi2Type
+    elseif (fmi2IsCoSimulation(fmu) && fmi2IsModelExchange(fmu) && type==:ME) || fmi2IsModelExchange(fmu)
+        fmu.type = fmi2ModelExchange::fmi2Type
+    else
+        error(unknownFMUType)
+    end
+
+    fmuName = fmi2GetModelIdentifier(fmu.modelDescription; type=fmu.type) # tmpName[length(tmpName)]
 
     directoryBinary = ""
     pathToBinary = ""
@@ -358,14 +367,6 @@ function fmi2Load(pathToFMU::String; unpackPath=nothing)
     fmu.libHandle = dlopen(pathToBinary)
 
     cd(lastDirectory)
-
-    if fmi2IsCoSimulation(fmu)
-        fmu.type = fmi2CoSimulation::fmi2Type
-    elseif fmi2IsModelExchange(fmu)
-        fmu.type = fmi2ModelExchange::fmi2Type
-    else
-        error(unknownFMUType)
-    end
 
     if fmi2IsCoSimulation(fmu) && fmi2IsModelExchange(fmu)
         @info "fmi2Load(...): FMU supports both CS and ME, using CS as default if nothing specified."

--- a/src/FMI2.jl
+++ b/src/FMI2.jl
@@ -313,9 +313,13 @@ function fmi2Load(pathToFMU::String; unpackPath=nothing, type=nothing)
     fmu.modelName = fmu.modelDescription.modelName
     fmu.instanceName = fmu.modelDescription.modelName
 
-    if (fmi2IsCoSimulation(fmu) && fmi2IsModelExchange(fmu) && (type===nothing || type==:CS)) || fmi2IsCoSimulation(fmu)
+    if (fmi2IsCoSimulation(fmu) && fmi2IsModelExchange(fmu) && type==:CS) 
         fmu.type = fmi2CoSimulation::fmi2Type
-    elseif (fmi2IsCoSimulation(fmu) && fmi2IsModelExchange(fmu) && type==:ME) || fmi2IsModelExchange(fmu)
+    elseif (fmi2IsCoSimulation(fmu) && fmi2IsModelExchange(fmu) && type==:ME)
+        fmu.type = fmi2ModelExchange::fmi2Type
+    elseif fmi2IsCoSimulation(fmu) && (type===nothing || type==:CS)
+        fmu.type = fmi2CoSimulation::fmi2Type
+    elseif fmi2IsModelExchange(fmu) && (type===nothing || type==:ME)
         fmu.type = fmi2ModelExchange::fmi2Type
     else
         error(unknownFMUType)

--- a/src/FMI2_md.jl
+++ b/src/FMI2_md.jl
@@ -54,23 +54,25 @@ function fmi2ReadModelDescription(pathToModellDescription::String)
 
     for node in eachelement(root)
 
-        if node.name == "CoSimulation"
-            md.isCoSimulation = true
-            md.CSmodelIdentifier                        = node["modelIdentifier"]
-            md.CScanHandleVariableCommunicationStepSize = parseNodeBoolean(node, "canHandleVariableCommunicationStepSize"   ; onfail=false)
-            md.CScanInterpolateInputs                   = parseNodeBoolean(node, "canInterpolateInputs"                     ; onfail=false)
-            md.CSmaxOutputDerivativeOrder               = parseNodeInteger(node, "maxOutputDerivativeOrder"                 ; onfail=-1)
-            md.CScanGetAndSetFMUstate                   = parseNodeBoolean(node, "canGetAndSetFMUstate"                     ; onfail=false)
-            md.CScanSerializeFMUstate                   = parseNodeBoolean(node, "canSerializeFMUstate"                     ; onfail=false)
-            md.CSprovidesDirectionalDerivative          = parseNodeBoolean(node, "providesDirectionalDerivative"            ; onfail=false)
+        if node.name == "CoSimulation" || node.name == "ModelExchange"
+            if node.name == "CoSimulation"
+                md.isCoSimulation = true
+                md.CSmodelIdentifier                        = node["modelIdentifier"]
+                md.CScanHandleVariableCommunicationStepSize = parseNodeBoolean(node, "canHandleVariableCommunicationStepSize"   ; onfail=false)
+                md.CScanInterpolateInputs                   = parseNodeBoolean(node, "canInterpolateInputs"                     ; onfail=false)
+                md.CSmaxOutputDerivativeOrder               = parseNodeInteger(node, "maxOutputDerivativeOrder"                 ; onfail=-1)
+                md.CScanGetAndSetFMUstate                   = parseNodeBoolean(node, "canGetAndSetFMUstate"                     ; onfail=false)
+                md.CScanSerializeFMUstate                   = parseNodeBoolean(node, "canSerializeFMUstate"                     ; onfail=false)
+                md.CSprovidesDirectionalDerivative          = parseNodeBoolean(node, "providesDirectionalDerivative"            ; onfail=false)
+            end
 
-        elseif node.name == "ModelExchange"
-            md.isModelExchange = true
-            md.MEmodelIdentifier                        = node["modelIdentifier"]
-            md.MEcanGetAndSetFMUstate                   = parseNodeBoolean(node, "canGetAndSetFMUstate"                     ; onfail=false)
-            md.MEcanSerializeFMUstate                   = parseNodeBoolean(node, "canSerializeFMUstate"                     ; onfail=false)
-            md.MEprovidesDirectionalDerivative          = parseNodeBoolean(node, "providesDirectionalDerivative"            ; onfail=false)
-
+            if node.name == "ModelExchange"
+                md.isModelExchange = true
+                md.MEmodelIdentifier                        = node["modelIdentifier"]
+                md.MEcanGetAndSetFMUstate                   = parseNodeBoolean(node, "canGetAndSetFMUstate"                     ; onfail=false)
+                md.MEcanSerializeFMUstate                   = parseNodeBoolean(node, "canSerializeFMUstate"                     ; onfail=false)
+                md.MEprovidesDirectionalDerivative          = parseNodeBoolean(node, "providesDirectionalDerivative"            ; onfail=false)
+            end
         elseif node.name == "TypeDefinitions"
             typedefinitions = node
 
@@ -171,13 +173,20 @@ end
 """
 Returns the tag 'modelIdentifier' from CS or ME section.
 """
-function fmi2GetModelIdentifier(md::fmi2ModelDescription)
-    if fmi2IsCoSimulation(md)
+function fmi2GetModelIdentifier(md::fmi2ModelDescription; type=nothing)
+    
+    if type === nothing
+        if fmi2IsCoSimulation(md)
+            return md.CSmodelIdentifier
+        elseif fmi2IsModelExchange(md)
+            return md.MEmodelIdentifier
+        else
+            @assert false "fmi2GetModelName(...): FMU does not support ME or CS!"
+        end
+    elseif type == fmi2CoSimulation
         return md.CSmodelIdentifier
-    elseif fmi2IsModelExchange(md)
+    elseif type == fmi2ModelExchange
         return md.MEmodelIdentifier
-    else
-        @assert false "fmi2GetModelName(...): FMU does not support ME or CS!"
     end
 end
 

--- a/src/FMI2_sim.jl
+++ b/src/FMI2_sim.jl
@@ -368,9 +368,9 @@ ToDo: Improove Documentation.
 """
 function fmi2Simulate(c::fmi2Component, t_start::Real = 0.0, t_stop::Real = 1.0; kwargs...)
 
-    if fmi2IsCoSimulation(c.fmu)
+    if c.fmu.type == fmi2CoSimulation
         return fmi2SimulateCS(c, t_start, t_stop; kwargs...)
-    elseif fmi2IsModelExchange(c.fmu)
+    elseif c.fmu.type == fmi2ModelExchange
         return fmi2SimulateME(c, t_start, t_stop; kwargs...)
     else
         error(unknownFMUType)

--- a/test/cs_me.jl
+++ b/test/cs_me.jl
@@ -1,0 +1,60 @@
+###############
+# Prepare FMU #
+###############
+
+pathToFMU = joinpath(dirname(@__FILE__), "..", "model", ENV["EXPORTINGTOOL"], "SpringPendulum1D.fmu")
+
+t_start = 0.0
+t_stop = 1.0
+
+myFMU = fmiLoad(pathToFMU)
+@test myFMU.type == FMI.fmi2CoSimulation
+@test fmi2IsCoSimulation(myFMU)
+@test fmi2IsModelExchange(myFMU)
+comp = fmiInstantiate!(myFMU; loggingOn=false)
+@test comp != 0
+# choose FMU or FMUComponent
+fmuStruct = nothing
+envFMUSTRUCT = ENV["FMUSTRUCT"]
+if envFMUSTRUCT == "FMU"
+    fmuStruct = myFMU
+elseif envFMUSTRUCT == "FMUCOMPONENT"
+    fmuStruct = comp
+end
+success = fmiSimulateCS(fmuStruct, t_start, t_stop)
+@test success
+sol, _ = fmiSimulateME(fmuStruct, t_start, t_stop)
+@test sol.retcode == :Success
+fmiUnload(myFMU)
+
+
+
+myFMU = fmiLoad(pathToFMU; type=:ME)
+@test myFMU.type == FMI.fmi2ModelExchange
+comp = fmiInstantiate!(myFMU; loggingOn=false)
+fmuStruct = nothing
+envFMUSTRUCT = ENV["FMUSTRUCT"]
+if envFMUSTRUCT == "FMU"
+    fmuStruct = myFMU
+elseif envFMUSTRUCT == "FMUCOMPONENT"
+    fmuStruct = comp
+end
+sol, _ = fmiSimulate(fmuStruct, t_start, t_stop)
+@test sol.retcode == :Success
+fmiUnload(myFMU)
+
+
+
+myFMU = fmiLoad(pathToFMU; type=:CS)
+@test myFMU.type == FMI.fmi2CoSimulation
+comp = fmiInstantiate!(myFMU; loggingOn=false)
+fmuStruct = nothing
+envFMUSTRUCT = ENV["FMUSTRUCT"]
+if envFMUSTRUCT == "FMU"
+    fmuStruct = myFMU
+elseif envFMUSTRUCT == "FMUCOMPONENT"
+    fmuStruct = comp
+end
+success = fmiSimulate(fmuStruct, t_start, t_stop)
+@test success
+fmiUnload(myFMU)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -36,6 +36,9 @@ function runtests(exportingTool)
                 @testset "ME Simulation" begin
                     include("sim_ME.jl")
                 end
+                @testset "Support CS and ME simultaneously" begin
+                    include("cs_me.jl")
+                end
             end
         end
 


### PR DESCRIPTION
Currently, when an FMU supports both CS and ME, it defaults to CS without giving the user an option to choose ME. It also links only the CS c-api. This PR changes that and gives the user more options.

CC: @ThummeTo @ChrisRackauckas