### PR TITLE
V0.13.0 ported for Documenter v1, export of fmi2&3Simulate functions

### DIFF
--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -10,7 +10,7 @@ on:
   pull_request:
   push:
     branches: 
-      - main
+      - v0.13.0
     paths:
       - 'docs/**'
       - 'README.md'

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,5 +1,6 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 
 [compat]
 julia = "1.6"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -6,6 +6,7 @@
 using Documenter, FMI, Plots
 using Documenter: GitHubActions
 
+println("I am a DEBUG print statement")
 makedocs(sitename="FMI.jl",
          format = Documenter.HTML(
             collapselevel = 1,

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -12,6 +12,7 @@ makedocs(sitename="FMI.jl",
             sidebar_sitename = false,
             edit_link = nothing
          ),
+         warnonly=true,
          pages= Any[
             "Introduction" => "index.md"
             "Features" => "features.md"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -3,7 +3,7 @@
 # Licensed under the MIT license. See LICENSE file in the project root for details.
 #
 
-using Documenter, FMI
+using Documenter, FMI, Plots
 using Documenter: GitHubActions
 
 makedocs(sitename="FMI.jl",

--- a/docs/src/library.md
+++ b/docs/src/library.md
@@ -17,21 +17,38 @@ fmiLoad
 fmiUnload
 fmiReload
 ```
-### Conversion functions
+
+# Conversion functions
 
 ```@docs
 fmiStringToValueReference
 ```
 
-### External/additional functions
+# External/additional functions
 
 ```@docs
 fmiGetDependencies
 fmiInfo
 ```
 
-### Visualize simulation results
+# Visualize simulation results
 
 ```@docs
 fmiPlot
+```
+
+# FMI2 specific
+
+```@docs
+fmi2Simulate
+fmi2SimulateME
+fmi2SimulateCS
+```
+
+# FMI3 specific
+
+```@docs
+fmi3Simulate
+fmi3SimulateME
+fmi3SimulateCS
 ```

--- a/src/FMI.jl
+++ b/src/FMI.jl
@@ -1054,13 +1054,13 @@ More detailed: `fmi3Struct = Union{FMU3, FMU3Instance}`
 See also [`fmi2SimulateME`](@ref) [`fmi2SimulateCS`](@ref), [`fmi2Simulate`](@ref), [`fmi2Struct`](@ref), [`FMU2`](@ref), [`FMU2Component`](@ref).
 
 """
-
 function fmiSimulateME(str::fmi2Struct, tspan::Union{Tuple{Float64, Float64}, Nothing}=nothing, args...; kwargs...)
     fmi2SimulateME(str, tspan, args...; kwargs...)
 end
 function fmiSimulateME(str::fmi3Struct, args...; kwargs...)
     fmi3SimulateME(str, args...; kwargs...)
 end
+
 """
     fmiUnload(fmu::Union{FMU2, FMU3})
 

--- a/src/FMI2/additional.jl
+++ b/src/FMI2/additional.jl
@@ -27,7 +27,6 @@ function fmi2VariableDependsOnVariable(fmu::FMU2, vr1::fmi2ValueReference, vr2::
 end
 
 """
-
     fmi2GetDependencies(fmu::FMU2)
 
 Building dependency matrix `dim x dim` for fast look-ups on variable dependencies (`dim` is number of states).
@@ -42,8 +41,6 @@ Building dependency matrix `dim x dim` for fast look-ups on variable dependencie
 - FMISpec2.0.2 Link: [https://fmi-standard.org/](https://fmi-standard.org/)
 - FMISpec2.0.2[p.22]: 2.1.4 Inquire Platform and Version Number of Header Files
 - FMISpec2.0.2[p.16]: 2.1.2 Platform Dependent Definitions
-
-See also [`fmi2GetDependencies`](@ref).
 """
 function fmi2GetDependencies(fmu::FMU2)
     if !isdefined(fmu, :dependencies)

--- a/src/FMI2/sim.jl
+++ b/src/FMI2/sim.jl
@@ -299,6 +299,30 @@ function setupODEProblem(c::FMU2Component, x0::AbstractArray{fmi2Real}, tspan::U
 end
 
 """
+    function fmi2SimulateME(fmu::FMU2, c::Union{FMU2Component, Nothing}=nothing, tspan::Union{Tuple{Float64, Float64}, Nothing}=nothing;
+                    tolerance::Union{Real, Nothing} = nothing,
+                    dt::Union{Real, Nothing} = nothing,
+                    solver = nothing,
+                    customFx = nothing,
+                    recordValues::fmi2ValueReferenceFormat = nothing,
+                    recordEventIndicators::Union{AbstractArray{<:Integer, 1}, UnitRange{<:Integer}, Nothing} = nothing,
+                    recordEigenvalues::Bool=false,
+                    saveat = nothing,
+                    x0::Union{AbstractArray{<:Real}, Nothing} = nothing,
+                    setup::Union{Bool, Nothing} = nothing,
+                    reset::Union{Bool, Nothing} = nothing,
+                    instantiate::Union{Bool, Nothing} = nothing,
+                    freeInstance::Union{Bool, Nothing} = nothing,
+                    terminate::Union{Bool, Nothing} = nothing,
+                    inputValueReferences::fmi2ValueReferenceFormat = nothing,
+                    inputFunction = nothing,
+                    parameters::Union{Dict{<:Any, <:Any}, Nothing} = nothing,
+                    dtmax::Union{Real, Nothing} = nothing,
+                    callbacksBefore = [],
+                    callbacksAfter = [],
+                    showProgress::Bool = true,
+                    kwargs...)
+
 ToDo: Update DocString
 
 Simulates a FMU instance for the given simulation time interval.
@@ -590,6 +614,8 @@ function fmi2SimulateME(fmu::FMU2, c::Union{FMU2Component, Nothing}=nothing, tsp
     return fmusol
 end
 
+export fmi2SimulateME
+
 # function fmi2SimulateME(fmu::FMU2, 
 #     c::Union{AbstractArray{<:Union{FMU2Component, Nothing}}, Nothing}=nothing, tspan::Union{Tuple{Float64, Float64}, Nothing}=nothing;
 #     x0::Union{AbstractArray{<:AbstractArray{<:Real}}, AbstractArray{<:Real}, Nothing} = nothing,
@@ -607,6 +633,21 @@ end
 ############ Co-Simulation ############
 
 """
+    fmi2SimulateCS(fmu::FMU2, c::Union{FMU2Component, Nothing}=nothing, tspan::Union{Tuple{Float64, Float64}, Nothing}=nothing;
+                    tolerance::Union{Real, Nothing} = nothing,
+                    dt::Union{Real, Nothing} = nothing,
+                    recordValues::fmi2ValueReferenceFormat = nothing,
+                    saveat = [],
+                    setup::Union{Bool, Nothing} = nothing,
+                    reset::Union{Bool, Nothing} = nothing,
+                    instantiate::Union{Bool, Nothing} = nothing,
+                    freeInstance::Union{Bool, Nothing} = nothing,
+                    terminate::Union{Bool, Nothing} = nothing,
+                    inputValueReferences::fmi2ValueReferenceFormat = nothing,
+                    inputFunction = nothing,
+                    showProgress::Bool=true,
+                    parameters::Union{Dict{<:Any, <:Any}, Nothing} = nothing)
+
 Starts a simulation of the Co-Simulation FMU instance.
 
 Via the optional keyword arguments `inputValues` and `inputFunction`, a custom input function `f(c, t)` or `f(t)` with time `t` and component `c` can be defined, that should return a array of values for `fmi2SetReal(..., inputValues, inputFunction(...))`.
@@ -778,6 +819,8 @@ function fmi2SimulateCS(fmu::FMU2, c::Union{FMU2Component, Nothing}=nothing, tsp
     return fmusol
 end
 
+export fmi2SimulateCS
+
 ##### CS & ME #####
 
 # wrapper
@@ -794,6 +837,8 @@ end
 # end
 
 """
+fmi2Simulate(fmu::FMU2, c::Union{FMU2Component, Nothing}=nothing, tspan::Union{Tuple{Float64, Float64}, Nothing}=nothing; kwargs...)
+
 Starts a simulation of the FMU instance for the matching FMU type, if both types are available, CS is preferred.
 
 Keywords:
@@ -822,3 +867,5 @@ function fmi2Simulate(fmu::FMU2, c::Union{FMU2Component, Nothing}=nothing, tspan
         error(unknownFMUType)
     end
 end
+
+export fmi2Simulate

--- a/src/FMI3/sim.jl
+++ b/src/FMI3/sim.jl
@@ -669,6 +669,27 @@ function setupODEProblem(c::FMU3Instance, x0::AbstractArray{fmi3Float64}, t_star
 end
 
 """
+    fmi3SimulateME(fmu::FMU3, c::Union{FMU3Instance, Nothing}=nothing, t_start::Union{Real, Nothing} = nothing, t_stop::Union{Real, Nothing} = nothing;
+                    tolerance::Union{Real, Nothing} = nothing,
+                    dt::Union{Real, Nothing} = nothing,
+                    solver = nothing,
+                    customFx = nothing,
+                    recordValues::fmi3ValueReferenceFormat = nothing,
+                    saveat = nothing,
+                    x0::Union{AbstractArray{<:Real}, Nothing} = nothing,
+                    setup::Union{Bool, Nothing} = nothing,
+                    reset::Union{Bool, Nothing} = nothing,
+                    instantiate::Union{Bool, Nothing} = nothing,
+                    freeInstance::Union{Bool, Nothing} = nothing,
+                    terminate::Union{Bool, Nothing} = nothing,
+                    inputValueReferences::fmi3ValueReferenceFormat = nothing,
+                    inputFunction = nothing,
+                    parameters::Union{Dict{<:Any, <:Any}, Nothing} = nothing,
+                    dtmax::Union{Real, Nothing} = nothing,
+                    callbacks = [],
+                    showProgress::Bool = true,
+                    kwargs...)
+
 Simulates a FMU instance for the given simulation time interval.
 State- and Time-Events are handled correctly.
 
@@ -891,6 +912,7 @@ function fmi3SimulateME(fmu::FMU3, c::Union{FMU3Instance, Nothing}=nothing, t_st
     return fmusol
 end
 
+export fmi3SimulateME
 
 # wrapper
 function fmi3SimulateCS(c::FMU3Instance, t_start::Union{Real, Nothing} = nothing, t_stop::Union{Real, Nothing} = nothing; kwargs...)
@@ -900,7 +922,22 @@ end
 ############ Co-Simulation ############
 
 """
-Starts a simulation of the Co-Simulation FMU instance.
+    fmi3SimulateCS(fmu::FMU3, c::Union{FMU3Instance, Nothing}=nothing, t_start::Union{Real, Nothing} = nothing, t_stop::Union{Real, Nothing} = nothing;
+                    tolerance::Union{Real, Nothing} = nothing,
+                    dt::Union{Real, Nothing} = nothing,
+                    recordValues::fmi3ValueReferenceFormat = nothing,
+                    saveat = [],
+                    setup::Union{Bool, Nothing} = nothing,
+                    reset::Union{Bool, Nothing} = nothing,
+                    instantiate::Union{Bool, Nothing} = nothing,
+                    freeInstance::Union{Bool, Nothing} = nothing,
+                    terminate::Union{Bool, Nothing} = nothing,
+                    inputValueReferences::fmi3ValueReferenceFormat = nothing,
+                    inputFunction = nothing,
+                    showProgress::Bool=true,
+                    parameters::Union{Dict{<:Any, <:Any}, Nothing} = nothing)
+
+                    Starts a simulation of the Co-Simulation FMU instance.
 
 Via the optional keyword arguments `inputValues` and `inputFunction`, a custom input function `f(c, t)` or `f(t)` with time `t` and instance `c` can be defined, that should return a array of values for `fmi3SetFloat64(..., inputValues, inputFunction(...))`.
 
@@ -1089,6 +1126,8 @@ function fmi3SimulateCS(fmu::FMU3, c::Union{FMU3Instance, Nothing}=nothing, t_st
     return fmusol
 end
 
+export fmi3SimulateCS
+
 # TODO simulate ScheduledExecution
 function fmi3SimulateSE(fmu::FMU3, c::Union{FMU3Instance, Nothing}=nothing, t_start::Union{Real, Nothing} = nothing, t_stop::Union{Real, Nothing} = nothing;
     tolerance::Union{Real, Nothing} = nothing,
@@ -1106,6 +1145,8 @@ function fmi3SimulateSE(fmu::FMU3, c::Union{FMU3Instance, Nothing}=nothing, t_st
     parameters::Union{Dict{<:Any, <:Any}, Nothing} = nothing)    @assert false "Not implemented"
 end
 
+export fmi3SimulateSE
+
 ##### CS & ME #####
 
 # wrapper
@@ -1114,6 +1155,8 @@ function fmi3Simulate(c::FMU3Instance, t_start::Union{Real, Nothing} = nothing, 
 end 
 
 """
+    fmi3Simulate(fmu::FMU3, c::Union{FMU3Instance, Nothing}=nothing, t_start::Union{Real, Nothing} = nothing, t_stop::Union{Real, Nothing} = nothing; kwargs...)
+
 Starts a simulation of the FMU instance for the matching FMU type, if both types are available, CS is preferred.
 
 Keywords:
@@ -1144,3 +1187,5 @@ function fmi3Simulate(fmu::FMU3, c::Union{FMU3Instance, Nothing}=nothing, t_star
         error(unknownFMUType)
     end
 end
+
+export  fmi3Simulate


### PR DESCRIPTION
Not yet implemented: References to FMICore and FMIImport documentation => requires fusion of doc for FMI, FMIImport, FMIExport, FMICore