### PR TITLE
Added Aqua.jl to tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 [![Coverage](https://codecov.io/gh/ThummeTo/FMI.jl/branch/main/graph/badge.svg)](https://codecov.io/gh/ThummeTo/FMI.jl)
 [![ColPrac: Contributor's Guide on Collaborative Practices for Community Packages](https://img.shields.io/badge/ColPrac-Contributor's%20Guide-blueviolet)](https://github.com/SciML/ColPrac)
 [![FMI Downloads](https://shields.io/endpoint?url=https://pkgs.genieframework.com/api/v1/badge/FMI)](https://pkgs.genieframework.com?packages=FMI)
+[![Aqua QA](https://raw.githubusercontent.com/JuliaTesting/Aqua.jl/master/badge.svg)](https://github.com/JuliaTesting/Aqua.jl)
 
 
 ## How can I use FMI.jl?

--- a/src/FMI.jl
+++ b/src/FMI.jl
@@ -108,7 +108,7 @@ export FMU3ExecutionConfiguration, FMU3_EXECUTION_CONFIGURATION_RESET, FMU3_EXEC
 
 using FMIImport: prepareValue, prepareValueReference
 
-export fmi2Real, fmi2Integer, fmi2String, fmi2Enumeration, fmi2Boolean
+export fmi2Real, fmi2Integer, fmi2String, fmi2Boolean
 export fmi2Info, fmi3Info
 export fmi2VariableDependsOnVariable, fmi2GetDependencies, fmi2PrintDependencies, fmi3VariableDependsOnVariable, fmi3GetDependencies, fmi3PrintDependencies
 

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,4 +1,5 @@
 [deps]
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
@@ -16,6 +17,7 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [compat]
+Aqua = "0.8"
 FMIZoo = "0.3.3"
 julia = "1.6"
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,6 +6,7 @@
 using FMI
 using FMIZoo
 using Test
+using Aqua
 import Random
 
 import FMI.FMIImport.FMICore: fmi2StatusOK, fmi3StatusOK, fmi2ComponentStateTerminated, fmi2ComponentStateInstantiated, fmi3Boolean
@@ -179,5 +180,15 @@ end
         end
     elseif Sys.isapple()
         @warn "Test-sets are currrently using Windows- and Linux-FMUs, automated testing for macOS is currently not supported."
+    end
+    @testset "Aqua.jl" begin
+        # Ambiguities in external packages
+        @testset "Method ambiguity" begin
+            Aqua.test_ambiguities([FMI])
+        end
+        @testset "Piracy" begin
+            Aqua.test_piracies(FMI; broken = true)
+        end
+        Aqua.test_all(FMI; ambiguities = false, piracies = false)
     end
 end


### PR DESCRIPTION
# Changes

- Added Aqua.jl to test cases
- Removed unused export (found by Aqua.jl)
- Added Aqua.jl badge to README.md

# Comments

- Ambiguities are tested only for FMI.jl until other packages incorporate Aqua.jl and resolve their ambiguities
- Piracies are currently broken