### PR TITLE
Improve Default Interval when using simulateCS

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "FMI"
 uuid = "14a09403-18e3-468f-ad8a-74f8dda2d9ac"
 authors = ["TT <tobias.thummerer@informatik.uni-augsburg.de>", "LM <lars.mikelsons@informatik.uni-augsburg.de>", "JK <josef.kircher@student.uni-augsburg.de>"]
-version = "0.14.1"
+version = "0.14.2"
 
 [deps]
 FMIExport = "31b88311-cab6-44ed-ba9c-fe5a9abbd67a"

--- a/src/sim.jl
+++ b/src/sim.jl
@@ -294,6 +294,7 @@ export simulateME
 function auto_interval(t)
     """
     Find a nice interval that divides t into 500 - 1000 steps
+    from https://github.com/CATIA-Systems/FMPy/blob/4166f08dd991cb6b5df2522ba125669e635327fe/fmpy/util.py#L1042
     """
     # Initial interval estimation
     h = 10 ^ (round(log10(t)) - 3)

--- a/src/sim.jl
+++ b/src/sim.jl
@@ -291,7 +291,33 @@ simulateME(fmu::FMU, tspan::Tuple{Float64,Float64}; kwargs...) =
 export simulateME
 
 ############ Co-Simulation ############
-
+function auto_interval(t)
+    """
+    Find a nice interval that divides t into 500 - 1000 steps
+    """
+    # Initial interval estimation
+    h = 10 ^ (round(log10(t)) - 3)
+    
+    # Number of samples
+    n_samples = t / h
+    
+    # Adjust interval based on number of samples
+    if n_samples >= 2500
+        h *= 5
+    elseif n_samples >= 2000
+        h *= 4
+    elseif n_samples >= 1000
+        h *= 2
+    elseif n_samples <= 200
+        h /= 5
+    elseif n_samples <= 250
+        h /= 4
+    elseif n_samples <= 500
+        h /= 2
+    end
+    
+    return h
+end
 """
     simulateCS(fmu, instance=nothing, tspan=nothing; kwargs...)
     simulateCS(fmu, tspan; kwargs...)
@@ -394,7 +420,7 @@ function simulateCS(
     tolerance = tolerance === nothing ? 0.0 : tolerance
 
     dt = dt === nothing ? getDefaultStepSize(fmu.modelDescription) : dt
-    dt = dt === nothing ? 1e-3 : dt
+    dt = dt === nothing ? auto_interval(t_stop-t_start) : dt
 
     @debug "Simulating CS-FMU: Preparing inputs ..."
     inputs = nothing


### PR DESCRIPTION
Currently, if the user doesnt pass `saveat` or `dt` to  `simulateCS`, we fall back to `dt=1e-3`, which is a decent default value for short Simulations, but leads to really long simulation times for longer timespans (`t_stop-t_start>10`). When not provided with any arguments, i would expect the simulation environment to pick a more sensible default value. Both Dymola and FMPy do this by picking a `dt` so that the number of saved values is 500 (Dymola) or 500-1000 (FMPy). This PR copies the behaviour from FMPy. 

As we dont have any other Files apart from `sim.jl`, i added `auto_interval` in there. Maybe it would make sense to put it in a new file like `utils.jl` or `helpers.jl`?

This could possibly be considered breaking because it somewhat changes the default behaviour?